### PR TITLE
Add MaybeReexecUsingUserNamespace()

### DIFF
--- a/bin/skiff.go
+++ b/bin/skiff.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/containers/storage/pkg/reexec"
+	"github.com/containers/storage/pkg/unshare"
 
 	"github.com/urfave/cli/v3"
 )
@@ -17,6 +18,7 @@ func main() {
 		Usage: "Analyze the disk usage and directory structure of OCI images and its layers",
 		Before: func(ctx context.Context, c *cli.Command) (context.Context, error) {
 			reexec.Init()
+			unshare.MaybeReexecUsingUserNamespace(false)
 			return ctx, nil
 		},
 		Commands: []*cli.Command{&LayerUsage},


### PR DESCRIPTION
This adds the required capabilities to the skiff process so that we can access podman's rootless storage