### PR TITLE
diff: add `skiff diff` between two images; show filesystem changes

### DIFF
--- a/cmd/skiff/diff.go
+++ b/cmd/skiff/diff.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	"text/tabwriter"
+
+	"go.podman.io/image/v5/types"
+	"github.com/urfave/cli/v3"
+
+	skiff "github.com/dcermak/skiff/pkg"
+)
+
+// FileDiff represents a file difference between two images
+type FileDiff struct {
+	Path       string
+	ChangeType string // "ADDED", "DELETED", "MODIFIED"
+	SizeDiff   int64  // positive for additions, negative for deletions
+}
+
+var diffCommand = cli.Command{
+	Name:  "diff",
+	Usage: "Show differences between two container images",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{Name: "human-readable", Usage: "Display sizes in human readable format (e.g., 1K, 234M, 2G)"},
+	},
+	Arguments: []cli.Argument{
+		&cli.StringArg{Name: "image1", UsageText: "First image reference"},
+		&cli.StringArg{Name: "image2", UsageText: "Second image reference"},
+	},
+	Action: func(ctx context.Context, c *cli.Command) error {
+		image1 := c.StringArg("image1")
+		image2 := c.StringArg("image2")
+		if image1 == "" || image2 == "" {
+			return fmt.Errorf("both image references are required")
+		}
+
+		sysCtx := types.SystemContext{}
+		return imageDiff(image1, image2, ctx, &sysCtx, c.Bool("human-readable"))
+	},
+}
+
+// imageDiff compares two images and shows their differences
+func imageDiff(uri1, uri2 string, ctx context.Context, sysCtx *types.SystemContext, humanReadable bool) error {
+	img1, _, err := skiff.ImageAndLayersFromURI(ctx, sysCtx, uri1)
+	if err != nil {
+		return fmt.Errorf("failed to load first image: %w", err)
+	}
+
+	img2, _, err := skiff.ImageAndLayersFromURI(ctx, sysCtx, uri2)
+	if err != nil {
+		return fmt.Errorf("failed to load second image: %w", err)
+	}
+
+	files1, err := skiff.ExtractFilesystem(ctx, img1, sysCtx)
+	if err != nil {
+		return fmt.Errorf("failed to extract filesystem from first image: %w", err)
+	}
+
+	files2, err := skiff.ExtractFilesystem(ctx, img2, sysCtx)
+	if err != nil {
+		return fmt.Errorf("failed to extract filesystem from second image: %w", err)
+	}
+
+	diffs := filesystemDiff(files1, files2)
+	displayDiffs(diffs, humanReadable)
+
+	return nil
+}
+
+// filesystemDiff compares two filesystem maps and returns differences
+func filesystemDiff(files1, files2 map[string]skiff.FileInfo) []FileDiff {
+	var diffs []FileDiff
+
+	// We're handling 3 cases:
+	// 1. DELETED: file exists in image1 but not in image2
+	// 2. MODIFIED: file exists in both images but has different size
+	// 3. ADDED: file exists in image2 but not in image1
+
+	// 1. DELETED: find files only in image1
+	for path, file1 := range files1 {
+		if _, exists := files2[path]; !exists {
+			diffs = append(diffs, FileDiff{
+				Path:       path,
+				ChangeType: "DELETED",
+				SizeDiff:   -file1.Size, // negative for deletions
+			})
+		}
+	}
+
+	for path, file2 := range files2 {
+		if file1, exists := files1[path]; exists {
+			// 2. MODIFIED: file exists in both images
+			if file1.Size != file2.Size {
+				diffs = append(diffs, FileDiff{
+					Path:       path,
+					ChangeType: "MODIFIED",
+					SizeDiff:   file2.Size - file1.Size,
+				})
+			}
+		} else {
+			// 3. ADDED: file exists in image2
+			diffs = append(diffs, FileDiff{
+				Path:       path,
+				ChangeType: "ADDED",
+				SizeDiff:   file2.Size, // positive for additions
+			})
+		}
+	}
+
+	// sort by path for consistent output
+	// TODO(danishprakash): optionally sorty by size diff
+	sort.Slice(diffs, func(i, j int) bool {
+		return diffs[i].Path < diffs[j].Path
+	})
+
+	return diffs
+}
+
+// displayDiffs displays the file differences in a formatted table
+func displayDiffs(diffs []FileDiff, humanReadable bool) {
+	if len(diffs) == 0 {
+		fmt.Println("No differences found between the images.")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.TabIndent)
+	defer w.Flush()
+
+	// header
+	fmt.Fprintln(w, "Change\tSize Diff\tPath")
+	for _, diff := range diffs {
+		var sizeStr string
+		if humanReadable {
+			if diff.SizeDiff > 0 {
+				sizeStr = "+" + skiff.HumanReadableSize(diff.SizeDiff)
+			} else {
+				sizeStr = "-" + skiff.HumanReadableSize(-diff.SizeDiff)
+			}
+		} else {
+			sizeStr = fmt.Sprintf("%+d", diff.SizeDiff)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", diff.ChangeType, sizeStr, diff.Path)
+	}
+}

--- a/cmd/skiff/main.go
+++ b/cmd/skiff/main.go
@@ -47,7 +47,7 @@ func main() {
 
 			return ctx, nil
 		},
-		Commands: []*cli.Command{&LayerUsage, &topCommand},
+		Commands: []*cli.Command{&LayerUsage, &topCommand, &diffCommand},
 	}
 
 	err := cmd.Run(context.Background(), os.Args)

--- a/features/diff.feature
+++ b/features/diff.feature
@@ -1,0 +1,61 @@
+Feature: `skiff diff` command
+
+  Scenario: Run `skiff diff` without any arguments
+    Given I run skiff with the subcommand "diff"
+    Then the exit code is 1
+    And stderr is
+      """
+      both image references are required
+      """
+
+  Scenario: Run `skiff diff` with only one image argument
+    Given I run skiff with the subcommand "diff registry.suse.com/bci/bci-busybox:15.6.33.3"
+    Then the exit code is 1
+    And stderr is
+      """
+      both image references are required
+      """
+
+  Scenario: Compare two different busybox images with human-readable output
+    Given I run skiff with the subcommand "diff --human-readable registry.suse.com/bci/bci-busybox:15.6.33.3 registry.suse.com/bci/bci-busybox:15.6.33.1"
+    Then the exit code is 0
+    And stdout is
+      """
+      Change    Size Diff  Path
+      MODIFIED  -320 B     /usr/lib/sysimage/rpm/Packages.db
+      MODIFIED  -39 B      /usr/share/busybox/busybox.links
+      """
+
+  Scenario: Compare two different busybox images without human-readable output
+    Given I run skiff with the subcommand "diff registry.suse.com/bci/bci-busybox:15.6.33.3 registry.suse.com/bci/bci-busybox:15.6.33.1"
+    Then the exit code is 0
+    And stdout is
+      """
+      Change    Size Diff  Path
+      MODIFIED  -320       /usr/lib/sysimage/rpm/Packages.db
+      MODIFIED  -39        /usr/share/busybox/busybox.links
+      """
+
+  Scenario: Compare images with non-existent first image
+    Given I run skiff with the subcommand "diff nonexistent:image registry.suse.com/bci/bci-busybox:15.6.33.3"
+    Then the exit code is 1
+    And stderr is
+      """
+      failed to load first image: reading manifest image in docker.io/library/nonexistent: requested access to the resource is denied
+      """
+
+  Scenario: Compare images with non-existent second image
+    Given I run skiff with the subcommand "diff registry.suse.com/bci/bci-busybox:15.6.33.3 nonexistent:image"
+    Then the exit code is 1
+    And stderr is
+      """
+      failed to load second image: reading manifest image in docker.io/library/nonexistent: requested access to the resource is denied
+      """
+
+  Scenario: Compare identical images (should show no differences)
+    Given I run skiff with the subcommand "diff registry.suse.com/bci/bci-busybox:15.6.33.3 registry.suse.com/bci/bci-busybox:15.6.33.3"
+    Then the exit code is 0
+    And stdout is
+      """
+      No differences found between the images.
+      """ 

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -105,3 +105,14 @@ def step_impl(context):
         raise AssertionError(
             f"Stdout doesn't equal:\n{expected}\n\nActual stdout:\n{found}"
         )
+
+
+@behave.step("stderr is")
+def step_impl(context):
+    expected = context.text.format(context=context).strip()
+    found = context.cmd_stderr.strip()
+
+    if expected != found:
+        raise AssertionError(
+            f"Stderr doesn't equal:\n{expected}\n\nActual stderr:\n{found}"
+        )

--- a/pkg/filesystem.go
+++ b/pkg/filesystem.go
@@ -1,0 +1,91 @@
+package skiff
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"go.podman.io/image/v5/pkg/blobinfocache/none"
+	"go.podman.io/image/v5/pkg/compression"
+	"go.podman.io/image/v5/types"
+	"github.com/opencontainers/go-digest"
+)
+
+// FileInfo represents a file in a container image
+type FileInfo struct {
+	Path   string
+	Size   int64
+	DiffID digest.Digest // diffID of the layer this file belongs to
+}
+
+// ExtractFilesystem extracts all files from an image's layers
+// Returns a map of file paths to FileInfo
+func ExtractFilesystem(ctx context.Context, img types.Image, sysCtx *types.SystemContext) (map[string]FileInfo, error) {
+	imgSrc, err := img.Reference().NewImageSource(ctx, sysCtx)
+	if err != nil {
+		return nil, err
+	}
+	defer imgSrc.Close()
+
+	layerInfos, err := BlobInfoFromImage(ctx, sysCtx, img)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blob info from image: %w", err)
+	}
+
+	conf, err := img.OCIConfig(ctx)
+	diffIDs := []digest.Digest{}
+	if err == nil && conf != nil && conf.RootFS.Type == "layers" {
+		diffIDs = conf.RootFS.DiffIDs
+	}
+
+	if len(layerInfos) != len(diffIDs) {
+		return nil, fmt.Errorf("layerInfos (%d) and diffIDs (%d) length mismatch", len(layerInfos), len(diffIDs))
+	}
+
+	files := make(map[string]FileInfo)
+
+	for i, layer := range layerInfos {
+		blob, _, err := imgSrc.GetBlob(ctx, layer, none.NoCache)
+		if err != nil {
+			return nil, err
+		}
+		defer blob.Close()
+
+		uncompressedStream, _, err := compression.AutoDecompress(blob)
+		if err != nil {
+			return nil, fmt.Errorf("auto-decompressing input: %w", err)
+		}
+		defer uncompressedStream.Close()
+
+		layerDiffID := diffIDs[i]
+
+		tr := tar.NewReader(uncompressedStream)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("failed to read tar header: %w", err)
+			}
+
+			path, err := filepath.Abs(filepath.Join("/", hdr.Name))
+			if err != nil {
+				return nil, fmt.Errorf("error generating absolute representation of path: %w", err)
+			}
+
+			// Only process regular files for now
+			if hdr.Typeflag == tar.TypeReg {
+				files[path] = FileInfo{
+					Path:   path,
+					Size:   hdr.Size,
+					DiffID: layerDiffID,
+				}
+			}
+		}
+	}
+
+	return files, nil
+}


### PR DESCRIPTION
```
$ skiff diff --human-readable registry.suse.com/bci/bci-busybox:15.6.33.3 registry.suse.com/bci/bci-busybox:15.6.33.1
Change    Size Diff  Path
MODIFIED  -320 B     /usr/lib/sysimage/rpm/Packages.db
MODIFIED  -39 B      /usr/share/busybox/busybox.links
```