### PR TITLE
mark /vendor/ as generated and exclude from diff generation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/vendor/** linguist-generated linguist-vendored -diff

--- a/.github/workflows/vendor-check.yml
+++ b/.github/workflows/vendor-check.yml
@@ -1,0 +1,25 @@
+---
+name: Vendor check
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+jobs:
+  vendor-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Regenerate vendor directory
+        run: make vendor-in-container
+
+      - name: Ensure vendor/ is up-to-date
+        run: |
+          if [ -n "$(git status --porcelain -- go.mod go.sum vendor/)" ]; then
+            git diff --text -- go.mod go.sum vendor/
+            echo "::error::vendor/ is out of date. Run 'make vendor-in-container' locally and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
Currently the /vendor/ subdir generates huge diffs on dependency bumps, but these are just noise as we autogenerate everything in them. With this, we tell github to exclude them from diffs and also exclude them from the local diff UI. The last has the catch though, that `git diff -- vendor/` or `log` or `git show` only shows binary files differ:
```
diff --git a/vendor/github.com/BurntSushi/toml/README.md b/vendor/github.com/BurntSushi/toml/README.md
index 1101d20..235496e 100644
Binary files a/vendor/github.com/BurntSushi/toml/README.md and b/vendor/github.com/BurntSushi/toml/README.md differ
diff --git a/vendor/github.com/BurntSushi/toml/decode.go b/vendor/github.com/BurntSushi/toml/decode.go
index ed88484..3fa516c 100644
Binary files a/vendor/github.com/BurntSushi/toml/decode.go and b/vendor/github.com/BurntSushi/toml/decode.go differ
```
imho that's _fine_

EDIT: actually, there's a very simple workaround, you can add the `--text` flag to `git diff` and `git log` and you'll get a textual diff for the /vendor/ subdir.